### PR TITLE
Use getLogger instead of Logger

### DIFF
--- a/xarm/core/utils/log.py
+++ b/xarm/core/utils/log.py
@@ -28,7 +28,7 @@ class Logger(logging.Logger):
     stream_handler.setLevel(logging.VERBOSE)
     stream_handler.setFormatter(logging.Formatter(stream_handler_fmt, stream_handler_date_fmt))
 
-    logger = logging.Logger(__name__)
+    logger = logging.getLogger(__name__)
     logger.setLevel(logging.VERBOSE)
     logger.addHandler(stream_handler)
 


### PR DESCRIPTION
Right now, the SDK constructs a new logger using `logging.Logger` rather than calling `logging.getLogger`.  This prevents projects from overwriting the log behavior, and integrating xArm's logs into their own.

This 3-character change fixes this, and does not change any other observable behaviors. 