### PR TITLE
Update PySerial version to 3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyserial==3.4
+pyserial==3.5


### PR DESCRIPTION
This should be backwards compatible and introduces some nice bugfixes for greater stability.  This will also improve compatibility with other Python packages.