### PR TITLE
fix: use raw strings for regex

### DIFF
--- a/xarm/x3/parse.py
+++ b/xarm/x3/parse.py
@@ -36,7 +36,7 @@ class GcodeParser:
 
     @staticmethod
     def __get_value(string, ch, return_type, default=None):
-        pattern = '{}(\-?\d+\.?\d*)'.format(ch)
+        pattern = r'{}(\-?\d+\.?\d*)'.format(ch)
         data = re.findall(pattern, string)
         if len(data) > 0:
             return return_type(data[0])
@@ -44,7 +44,7 @@ class GcodeParser:
 
     @staticmethod
     def __get_hex_value(string, ch, default=None):
-        pattern = '{}(-?\w{{3,4}})'.format(ch)
+        pattern = r'{}(-?\w{{3,4}})'.format(ch)
         data = re.findall(pattern, string)
         if len(data) > 0:
             return int(data[0], base=16)


### PR DESCRIPTION
as described in this [stackoverflow post](https://stackoverflow.com/a/77531416), regex escape sequences must use raw string literals. This PR changes the two problematic regex strings with invalid string literals to raw strings.

```
    from xarm.core.config import x_code  # type: ignore
../.pyenv/versions/3.11.4/lib/python3.11/site-packages/xarm/__init__.py:1: in <module>
    from .wrapper import XArmAPI
../.pyenv/versions/3.11.4/lib/python3.11/site-packages/xarm/wrapper/__init__.py:1: in <module>
    from .xarm_api import XArmAPI
../.pyenv/versions/3.11.4/lib/python3.11/site-packages/xarm/wrapper/xarm_api.py:9: in <module>
    from ..x3 import XArm, Studio
../.pyenv/versions/3.11.4/lib/python3.11/site-packages/xarm/x3/__init__.py:1: in <module>
    from .xarm import XArm
../.pyenv/versions/3.11.4/lib/python3.11/site-packages/xarm/x3/xarm.py:24: in <module>
    from .parse import GcodeParser
E     File "/home/circleci/.pyenv/versions/3.11.4/lib/python3.11/site-packages/xarm/x3/parse.py", line 39
E       pattern = '{}(\-?\d+\.?\d*)'.format(ch)
E                 ^^^^^^^^^^^^^^^^^^
E   SyntaxError: invalid escape sequence '\-'

``` 

@vimior 